### PR TITLE
fix: properly alias react to preact

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -19,18 +19,21 @@
     "preact": "https://esm.sh/preact@10.15.1",
     "preact/": "https://esm.sh/preact@10.15.1/",
     "preact-render-to-string": "https://esm.sh/*preact-render-to-string@6.2.0",
+    "react": "https://esm.sh/preact@10.15.1/compat",
+    "react-dom": "https://esm.sh/preact@10.15.1/compat",
+    "react/jsx-runtime": "https://esm.sh/preact@10.15.1/compat",
     "@preact/signals": "https://esm.sh/*@preact/signals@1.1.3",
     "@preact/signals-core": "https://esm.sh/*@preact/signals-core@1.2.3",
     "twind-preset-tailwind/": "https://esm.sh/@twind/preset-tailwind@1.1.4/",
     "twind-preset-ext": "https://esm.sh/@twind/preset-ext@1.0.7/",
     "@twind/core": "https://esm.sh/@twind/core@1.1.3",
     "@twind/preset-autoprefix" : "https://esm.sh/@twind/preset-autoprefix@1.0.7",
-    "@radix-ui/colors": "https://esm.sh/@radix-ui/colors@1.0.0",
-    "@radix-ui/react-avatar": "https://esm.sh/@radix-ui/react-avatar@1.0.3?alias=react:preact/compat,react-dom:preact/compat,@types/react:preact/compat&external=preact/compat",
-    "@radix-ui/react-dropdown-menu": "https://esm.sh/@radix-ui/react-dropdown-menu@2.0.5?alias=react:preact/compat,react-dom:preact/compat,@types/react:preact/compat&external=preact/compat",
-    "@radix-ui/react-icons": "https://esm.sh/@radix-ui/react-icons@1.3.0?alias=react:preact/compat,react-dom:preact/compat,@types/react:preact/compat&external=preact/compat",
-    "@radix-ui/react-alert-dialog": "https://esm.sh/@radix-ui/react-alert-dialog@1.0.4?alias=react:preact/compat,react-dom:preact/compat,@types/react:preact/compat&external=preact/compat",
-    "@radix-ui/react-progress": "https://esm.sh/@radix-ui/react-progress@1.0.3?alias=react:preact/compat,react-dom:preact/compat,@types/react:preact/compat&external=preact/compat"
+    "@radix-ui/colors": "https://esm.sh/@radix-ui/colors@1.0.0?external=react,react-dom&target=es2022",
+    "@radix-ui/react-avatar": "https://esm.sh/@radix-ui/react-avatar@1.0.3?external=react,react-dom&target=es2022",
+    "@radix-ui/react-dropdown-menu": "https://esm.sh/@radix-ui/react-dropdown-menu@2.0.5?external=react,react-dom&target=es2022",
+    "@radix-ui/react-icons": "https://esm.sh/@radix-ui/react-icons@1.3.0?external=react,react-dom&target=es2022",
+    "@radix-ui/react-alert-dialog": "https://esm.sh/@radix-ui/react-alert-dialog@1.0.4?external=react,react-dom&target=es2022",
+    "@radix-ui/react-progress": "https://esm.sh/@radix-ui/react-progress@1.0.3?external=react,react-dom&target=es2022"
 
   },
   "compilerOptions": {


### PR DESCRIPTION
This PR fixes the aliasing of all radix ui `react` and `react-dom` dependencies to `preact/compat`.

With that the Modal etc works:

![Screenshot 2023-07-25 at 21 30 56](https://github.com/hapaxlife/test-fresh-radix-ui/assets/1062408/71310d63-fbab-4f8c-a911-428174ce4c4d)
